### PR TITLE
More usable schema errors.

### DIFF
--- a/flask_expects_json/__init__.py
+++ b/flask_expects_json/__init__.py
@@ -23,7 +23,7 @@ def expects_json(schema=None, force=False, fill_defaults=False):
                 else:
                     validate(data, schema)
             except ValidationError as e:
-                return abort(400, e.message)
+                return abort(400, str(e))
 
             g.data = data
             return f(*args, **kwargs)


### PR DESCRIPTION
Using the string representation of the ValidationError will show the human-readable message, the relevant schema information for the offending element, and the path to the offending element in the JSON being validated. This will make it far easier for a developer coding against an API that uses flask-expects-json to debug what, exactly, was the problem with the JSON they submitted when it doesn't validate against the schema.

Docs regarding ValidationError and its string representation: https://github.com/Julian/jsonschema/blob/master/docs/errors.rst