### PR TITLE
Filter non-body HTTP requests

### DIFF
--- a/flask_expects_json/__init__.py
+++ b/flask_expects_json/__init__.py
@@ -12,6 +12,9 @@ def expects_json(schema=None, force=False, fill_defaults=False):
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
+            if request.method in ['HEAD', 'GET', 'DELETE']:
+                return f(*args, **kwargs)
+            
             data = request.get_json(force=force)
 
             if data is None:

--- a/flask_expects_json/__init__.py
+++ b/flask_expects_json/__init__.py
@@ -5,16 +5,19 @@ from jsonschema import validate, ValidationError
 from .default_validator import DefaultValidatingDraft4Validator
 
 
-def expects_json(schema=None, force=False, fill_defaults=False):
+def expects_json(schema=None, force=False, fill_defaults=False, ignore_for=None):
     if schema is None:
         schema = dict()
+    if ignore_for is not None:
+        if isinstance(ignore_for, str):
+            raise TypeError('Methods should be wrapped in an iterable. i.e. ignore_for=["GET"]')
 
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
-            if request.method in ['HEAD', 'GET', 'DELETE']:
+            if ignore_for is not None and request.method in ignore_for:
                 return f(*args, **kwargs)
-            
+
             data = request.get_json(force=force)
 
             if data is None:

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -1,0 +1,51 @@
+import unittest
+import flask
+
+from flask_expects_json import expects_json
+
+
+class TestExpects(unittest.TestCase):
+    def setUp(self):
+        self.app = flask.Flask(__name__)
+
+        @self.app.route('/')
+        @expects_json()
+        def all_requests():
+            return 'happy'
+
+        @self.app.route('/ignore_one', methods=['GET', 'POST'])
+        @expects_json(ignore_for=['GET'])
+        def ignore_get():
+            return 'happy'
+
+        @self.app.route('/ignore_two', methods=['GET', 'HEAD', 'POST'])
+        @expects_json(ignore_for=['GET', 'HEAD'])
+        def ignore_get_head():
+            return 'happy'
+
+        self.client = self.app.test_client()
+        self.ctx = self.app.app_context()
+        self.ctx.push()
+
+    def test_default_behaviour(self):
+        response = self.client.get('/')
+        self.assertEqual(400, response.status_code)
+        self.assertIn('Failed to decode', response.data.decode())
+        response = self.client.get('/', data='{}', content_type='application/json')
+        self.assertEqual(200, response.status_code)
+
+    def test_ignore_one(self):
+        response = self.client.get('/ignore_one')
+        self.assertEqual(200, response.status_code)
+        response = self.client.post('/ignore_one', data='')
+        self.assertIn('Failed to decode', response.data.decode())
+        self.assertEqual(400, response.status_code)
+
+    def test_ignore_multiple(self):
+        response = self.client.get('/ignore_two')
+        self.assertEqual(200, response.status_code)
+        response = self.client.head('/ignore_two')
+        self.assertEqual(200, response.status_code)
+        response = self.client.post('/ignore_two', data='')
+        self.assertIn('Failed to decode', response.data.decode())
+        self.assertEqual(400, response.status_code)

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -8,12 +8,12 @@ class TestExpects(unittest.TestCase):
     def setUp(self):
         self.app = flask.Flask(__name__)
 
-        @self.app.route('/')
+        @self.app.route('/', methods=['GET', 'HEAD', 'POST'])
         @expects_json()
         def all_requests():
             return 'happy'
 
-        @self.app.route('/ignore_one', methods=['GET', 'POST'])
+        @self.app.route('/ignore_one', methods=['GET', 'HEAD', 'POST'])
         @expects_json(ignore_for=['GET'])
         def ignore_get():
             return 'happy'
@@ -31,15 +31,21 @@ class TestExpects(unittest.TestCase):
         response = self.client.get('/')
         self.assertEqual(400, response.status_code)
         self.assertIn('Failed to decode', response.data.decode())
+        response = self.client.head('/')
+        self.assertEqual(400, response.status_code)
         response = self.client.get('/', data='{}', content_type='application/json')
         self.assertEqual(200, response.status_code)
 
     def test_ignore_one(self):
         response = self.client.get('/ignore_one')
         self.assertEqual(200, response.status_code)
-        response = self.client.post('/ignore_one', data='')
-        self.assertIn('Failed to decode', response.data.decode())
+        response = self.client.head('/ignore_one')
         self.assertEqual(400, response.status_code)
+        response = self.client.post('/ignore_one', data='')
+        self.assertEqual(400, response.status_code)
+        self.assertIn('Failed to decode', response.data.decode())
+        response = self.client.get('/ignore_one', data='{}', content_type='application/json')
+        self.assertEqual(200, response.status_code)
 
     def test_ignore_multiple(self):
         response = self.client.get('/ignore_two')
@@ -47,5 +53,7 @@ class TestExpects(unittest.TestCase):
         response = self.client.head('/ignore_two')
         self.assertEqual(200, response.status_code)
         response = self.client.post('/ignore_two', data='')
-        self.assertIn('Failed to decode', response.data.decode())
         self.assertEqual(400, response.status_code)
+        self.assertIn('Failed to decode', response.data.decode())
+        response = self.client.get('/ignore_two', data='{}', content_type='application/json')
+        self.assertEqual(200, response.status_code)


### PR DESCRIPTION
Added a whitelist to skip validation for requests that don't contain a body.