### PR TITLE
Optional format validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ def insecure():
     return 'This view will validate the data no matter the mimetype.'
 ```
 
+## Format checking
+
+As of 1.6.0 you can set `check_formats=True` or `check_formats=['list of format']` to enable validating formats such as `email` `date-time`. This is set to `False` by default.
+
 ## Default values
 
 Normally validators wont touch the data. By default this package will not fill in missing default values provided in the schema. If you want to you can set `fill_defaults=True` explicitly. The validation will be performed after this action, so default values can lead to invalid data.

--- a/flask_expects_json/__init__.py
+++ b/flask_expects_json/__init__.py
@@ -1,8 +1,8 @@
 from functools import wraps
 from flask import request, g, abort
 
-from jsonschema import validate, ValidationError
-from .default_validator import DefaultValidatingDraft4Validator
+from jsonschema import validate, ValidationError, FormatChecker
+from .default_validator import ExtendedDefaultValidator
 
 
 def expects_json(schema=None, force=False, fill_defaults=False, ignore_for=None):
@@ -24,10 +24,12 @@ def expects_json(schema=None, force=False, fill_defaults=False, ignore_for=None)
                 return abort(400, 'Failed to decode JSON object')
 
             try:
+                format_checker = FormatChecker()
+
                 if fill_defaults:
-                    DefaultValidatingDraft4Validator(schema).validate(data)
+                    ExtendedDefaultValidator(schema, format_checker=format_checker).validate(data)
                 else:
-                    validate(data, schema)
+                    validate(data, schema, format_checker=format_checker)
             except ValidationError as e:
                 return abort(400, e)
 

--- a/flask_expects_json/default_validator.py
+++ b/flask_expects_json/default_validator.py
@@ -1,4 +1,5 @@
-from jsonschema import Draft4Validator, validators
+from jsonschema import validators
+from jsonschema.validators import _LATEST_VERSION as LATEST_VALIDATOR
 
 
 def extend_with_default(validator_class):
@@ -19,4 +20,4 @@ def extend_with_default(validator_class):
     )
 
 
-DefaultValidatingDraft4Validator = extend_with_default(Draft4Validator)
+ExtendedDefaultValidator = extend_with_default(LATEST_VALIDATOR)


### PR DESCRIPTION
#15 
This PR:
- Removed Draft4 validator from filling defaults
- Enables you to optionally check for formats such as email, date-time, date etc.

After we discuss if this is the correct way to implement it, we can implement tests. Thank you.