### PR TITLE
Support flask async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ htmlcov/
 *.pyc
 *.egg-info
 .coverage
+
+# JetBrain IDE
+.idea

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Use pip to install the package from PyPI:
 pip install flask-expects-json
 ```
 
+If you are intending to install async version:
+
+```bash
+pip install flask-expects-json[async]
+```
+Note: the above command is not necessary in order to install a version
+of flask-expect-json that supports async, however, the above command
+will ensure `flask[async]` is installed as a dependency.
+
 ## Usage
 
 This package provides a flask route decorator to validate json payload.

--- a/flask_expects_json/__init__.py
+++ b/flask_expects_json/__init__.py
@@ -1,7 +1,7 @@
 from functools import wraps
 from typing import Iterable
 
-from flask import request, g, abort
+from flask import request, g, abort, current_app
 
 from jsonschema import validate, ValidationError, FormatChecker
 from .default_validator import ExtendedDefaultValidator
@@ -44,6 +44,10 @@ def expects_json(schema=None, force=False, fill_defaults=False, ignore_for=None,
                 return abort(400, e)
 
             g.data = data
-            return f(*args, **kwargs)
+
+            if hasattr(current_app, "ensure_sync"):
+                return current_app.ensure_sync(f)(*args, **kwargs)
+            else:
+                return f(*args, **kwargs)
         return decorated_function
     return decorator

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,8 @@ setup(
         'flask>=1.0.2',
         'jsonschema>=3.0.1'
     ],
+    extras_require={
+        "async": ["flask[async]>=2.0.0"],
+    },
     test_suite='tests.test_suite'
 )

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -40,6 +40,16 @@ class TestDefaults(unittest.TestCase):
         def default():
             return ''
 
+        @self.app.route('/valid_async')
+        @expects_json({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "default": 5}
+            }
+        })
+        async def default_async():
+            return ''
+
         self.client = self.app.test_client()
         self.ctx = self.app.app_context()
         self.ctx.push()
@@ -56,6 +66,12 @@ class TestDefaults(unittest.TestCase):
         self.assertIn('name', flask.g.data)
         self.assertEqual(5.3, flask.g.data['price'])
         self.assertIn('hubert', flask.g.data['name'])
+
+    def test_async_default_works(self):
+        response = self.client.get('/valid_async',
+                                   data='{}',
+                                   content_type='application/json')
+        self.assertEqual(200, response.status_code)
 
     def test_default_gets_validated(self):
         response = self.client.get('/invalid',

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -13,6 +13,11 @@ class TestExpects(unittest.TestCase):
         def no_schema():
             return 'happy'
 
+        @self.app.route('/no_schema_async')
+        @expects_json()
+        async def no_schema_async():
+            return 'happy'
+
         @self.app.route('/schema')
         @expects_json({
             "type": "object",
@@ -31,6 +36,13 @@ class TestExpects(unittest.TestCase):
 
     def test_valid_decorator(self):
         response = self.client.get('/')
+        self.assertEqual(400, response.status_code)
+        self.assertIn('Failed to decode', response.data.decode())
+        response = self.client.get('/', data='{}', content_type='application/json')
+        self.assertEqual(200, response.status_code)
+
+    def test_valid_decorator_no_schema_async(self):
+        response = self.client.get('/no_schema_async')
         self.assertEqual(400, response.status_code)
         self.assertIn('Failed to decode', response.data.decode())
         response = self.client.get('/', data='{}', content_type='application/json')


### PR DESCRIPTION
Hi, @Fischerfredl,

I'm just trying to add `flask[async]` support, appreciate for any feedback if you are unhappy with the current approach.

I've added new test cases, ensure all unit tests are passing locally.

PS: I've also updated `.gitignore` to exclude jetbrain (pycharm) IDE


```
============================= test session starts ==============================
collecting ... collected 19 items

test_defaults.py::TestDefaults::test_async_default_works PASSED          [  5%]
test_defaults.py::TestDefaults::test_default_gets_validated PASSED       [ 10%]
test_defaults.py::TestDefaults::test_default_off_by_default PASSED       [ 15%]
test_defaults.py::TestDefaults::test_default_works PASSED                [ 21%]
test_defaults.py::TestDefaults::test_setdefault_on_string PASSED         [ 26%]
test_format_validation.py::TestDefaults::test_format_validation_happy_path PASSED [ 31%]
test_format_validation.py::TestDefaults::test_format_validation_off_by_default PASSED [ 36%]
test_format_validation.py::TestDefaults::test_format_validation_rejection PASSED [ 42%]
test_ignore.py::TestExpects::test_default_behaviour PASSED               [ 47%]
test_ignore.py::TestExpects::test_ignore_multiple PASSED                 [ 52%]
test_ignore.py::TestExpects::test_ignore_one PASSED                      [ 57%]
test_requests.py::TestExpects::test_check_mimetype PASSED                [ 63%]
test_requests.py::TestExpects::test_check_null PASSED                    [ 68%]
test_requests.py::TestExpects::test_valid_decorator PASSED               [ 73%]
test_requests.py::TestExpects::test_valid_decorator_no_schema_async PASSED [ 78%]
test_schema.py::TestExpects::test_additional_parameter PASSED            [ 84%]
test_schema.py::TestExpects::test_missing_parameter PASSED               [ 89%]
test_schema.py::TestExpects::test_validation_invalid PASSED              [ 94%]
test_schema.py::TestExpects::test_validation_valid PASSED                [100%]

============================== 19 passed in 0.12s ==============================

Process finished with exit code 0

```
